### PR TITLE
Structures now properly added to valid biomes.

### DIFF
--- a/src/main/java/svenhjol/strange/base/helper/VersionHelper.java
+++ b/src/main/java/svenhjol/strange/base/helper/VersionHelper.java
@@ -17,19 +17,20 @@ public class VersionHelper {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public static void addStructureToBiome(Structure structure, Biome biome) {
-        // 1.14
-//        biome.addFeature(
-//            GenerationStage.Decoration.UNDERGROUND_STRUCTURES,
-//            Biome.createDecoratedFeature(structure, IFeatureConfig.NO_FEATURE_CONFIG, Placement.NOPE, IPlacementConfig.NO_PLACEMENT_CONFIG));
-//
-//        biome.addStructure(structure, IFeatureConfig.NO_FEATURE_CONFIG);
+    public static void addStructureToBiomeFeature(Structure structure, Biome biome) {
 
         // 1.15
         final ConfiguredFeature configured = structure.withConfiguration(NoFeatureConfig.NO_FEATURE_CONFIG);
         final ConfiguredFeature decorated = configured.withPlacement(Placement.NOPE.configure(IPlacementConfig.NO_PLACEMENT_CONFIG));
 
         biome.addFeature(GenerationStage.Decoration.UNDERGROUND_STRUCTURES, decorated);
+    }
+    
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static void addStructureToBiomeStructure(Structure structure, Biome biome) {
+        // 1.15
+        final ConfiguredFeature configured = structure.withConfiguration(NoFeatureConfig.NO_FEATURE_CONFIG);
+
         biome.addStructure(configured);
     }
 }

--- a/src/main/java/svenhjol/strange/ruins/module/UndergroundRuins.java
+++ b/src/main/java/svenhjol/strange/ruins/module/UndergroundRuins.java
@@ -1,5 +1,11 @@
 package svenhjol.strange.ruins.module;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import net.minecraft.item.FilledMapItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -8,18 +14,24 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.Biome.Category;
 import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.feature.NoFeatureConfig;
 import net.minecraft.world.gen.feature.structure.Structure;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.storage.MapData;
 import net.minecraft.world.storage.MapDecoration;
-import net.minecraft.world.storage.loot.*;
+import net.minecraft.world.storage.loot.ItemLootEntry;
+import net.minecraft.world.storage.loot.LootEntry;
+import net.minecraft.world.storage.loot.LootParameters;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraft.world.storage.loot.LootTables;
 import net.minecraftforge.event.LootTableLoadEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartedEvent;
 import net.minecraftforge.registries.ForgeRegistries;
+import svenhjol.meson.Meson;
 import svenhjol.meson.MesonModule;
 import svenhjol.meson.handler.RegistryHandler;
 import svenhjol.meson.helper.LootHelper;
@@ -27,14 +39,11 @@ import svenhjol.meson.iface.Config;
 import svenhjol.meson.iface.Module;
 import svenhjol.strange.Strange;
 import svenhjol.strange.base.StrangeCategories;
-import svenhjol.strange.base.helper.StructureHelper;
 import svenhjol.strange.base.helper.StructureHelper.RegisterJigsawPieces;
 import svenhjol.strange.base.helper.VersionHelper;
 import svenhjol.strange.ruins.structure.MarkerPiece;
 import svenhjol.strange.ruins.structure.UndergroundPiece;
 import svenhjol.strange.ruins.structure.UndergroundStructure;
-
-import java.util.*;
 
 @Module(mod = Strange.MOD_ID, category = StrangeCategories.RUINS, hasSubscriptions = true,
     description = "Ruins that spawn underground with different types according to biome.")
@@ -80,13 +89,20 @@ public class UndergroundRuins extends MesonModule {
 
     @Override
     public void onCommonSetup(FMLCommonSetupEvent event) {
-        final List<Biome> endBiomes = StructureHelper.getEndBiomes();
+//        final List<Biome> endBiomes = StructureHelper.getEndBiomes();
 
         for (Biome biome : ForgeRegistries.BIOMES) {
-            if (endBiomes.contains(biome))
-                continue;
+        	//see below (line 97) for alternative way for not adding the structure to both vanilla and modded end biomes
+//            if (endBiomes.contains(biome)) 
+//                continue;
 
-            VersionHelper.addStructureToBiome(structure, biome);
+            
+            //Structure can finish generating in any biome so it doesn't get cut off.
+            VersionHelper.addStructureToBiomeFeature(structure, biome);
+            
+            //Only non-end biomes can start the structure generation.
+            if(biome.getCategory() != Category.THEEND && Meson.isModuleEnabled("strange:underground_ruins"))
+                VersionHelper.addStructureToBiomeStructure(structure, biome);
         }
     }
 

--- a/src/main/java/svenhjol/strange/ruins/module/Vaults.java
+++ b/src/main/java/svenhjol/strange/ruins/module/Vaults.java
@@ -1,5 +1,9 @@
 package svenhjol.strange.ruins.module;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import net.minecraft.item.FilledMapItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -14,7 +18,11 @@ import net.minecraft.world.gen.feature.structure.Structure;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.storage.MapData;
 import net.minecraft.world.storage.MapDecoration;
-import net.minecraft.world.storage.loot.*;
+import net.minecraft.world.storage.loot.ItemLootEntry;
+import net.minecraft.world.storage.loot.LootEntry;
+import net.minecraft.world.storage.loot.LootParameters;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraft.world.storage.loot.LootTables;
 import net.minecraftforge.event.LootTableLoadEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -33,10 +41,6 @@ import svenhjol.strange.base.helper.VersionHelper;
 import svenhjol.strange.outerlands.module.Outerlands;
 import svenhjol.strange.ruins.structure.VaultPiece;
 import svenhjol.strange.ruins.structure.VaultStructure;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 @Module(mod = Strange.MOD_ID, category = StrangeCategories.RUINS, hasSubscriptions = true,
     description = "Large underground complexes with rare treasure.")
@@ -60,7 +64,7 @@ public class Vaults extends MesonModule {
     @Config(name = "Generate above Y value", description = "Vaults will try and generate above this Y value.")
     public static int generateAbove = 24;
 
-    public static final List<Biome> validBiomes = new ArrayList<>();
+    public static final List<Biome> validBiomes = new ArrayList<Biome>();
 
     @Override
     public void init() {
@@ -72,18 +76,26 @@ public class Vaults extends MesonModule {
 
     @Override
     public void onCommonSetup(FMLCommonSetupEvent event) {
-        final List<Biome> overworldBiomes = StructureHelper.getOverworldBiomes();
-
-        ForgeRegistries.BIOMES.forEach(biome -> {
-            if (!overworldBiomes.contains(biome))
-                return;
-
-            VersionHelper.addStructureToBiome(structure, biome);
-        });
+//        final List<Biome> overworldBiomes = StructureHelper.getOverworldBiomes();
 
         validBiomes.addAll(Arrays.asList(
             Biomes.MOUNTAINS, Biomes.MOUNTAIN_EDGE
         ));
+        
+        ForgeRegistries.BIOMES.forEach(biome -> {
+        	// This is commented out so modded biomes gets the structure added as a 
+        	// feature and wont cut off vaults if those biomes border a mountain biome 
+        	// and the vault tries to spawn on the border.
+//            if (!overworldBiomes.contains(biome))  
+//                return;
+
+            //Structure can finish generating in any biome so it doesn't get cut off.
+            VersionHelper.addStructureToBiomeFeature(structure, biome);
+            
+            //Only these biomes can start the structure generation.
+            if(validBiomes.contains(biome) && Meson.isModuleEnabled("strange:vaults"))
+                VersionHelper.addStructureToBiomeStructure(structure, biome);
+        });
     }
 
     @Override

--- a/src/main/java/svenhjol/strange/ruins/structure/UndergroundStructure.java
+++ b/src/main/java/svenhjol/strange/ruins/structure/UndergroundStructure.java
@@ -51,9 +51,6 @@ public class UndergroundStructure extends ScatteredStructure<NoFeatureConfig> {
 
         if (x == chunk.x && z == chunk.z) {
             if (gen.hasStructure(biome, UndergroundRuins.structure)) {
-                if (!Meson.isModuleEnabled("strange:underground_ruins"))
-                    return false;
-
                 for (int k = x - 10; k <= x + 10; ++k) {
                     for (int l = z - 10; l <= z + 10; ++l) {
                         for (Structure<?> structure : UndergroundRuins.blacklist) {

--- a/src/main/java/svenhjol/strange/ruins/structure/VaultStructure.java
+++ b/src/main/java/svenhjol/strange/ruins/structure/VaultStructure.java
@@ -1,5 +1,8 @@
 package svenhjol.strange.ruins.structure;
 
+import java.util.Objects;
+import java.util.Random;
+
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
@@ -14,12 +17,8 @@ import net.minecraft.world.gen.feature.structure.ScatteredStructure;
 import net.minecraft.world.gen.feature.structure.Structure;
 import net.minecraft.world.gen.feature.structure.StructureStart;
 import net.minecraft.world.gen.feature.template.TemplateManager;
-import svenhjol.meson.Meson;
 import svenhjol.strange.Strange;
 import svenhjol.strange.ruins.module.Vaults;
-
-import java.util.Objects;
-import java.util.Random;
 
 public class VaultStructure extends ScatteredStructure<NoFeatureConfig> {
     public static final int SEED_MODIFIER = 188492881;
@@ -48,9 +47,7 @@ public class VaultStructure extends ScatteredStructure<NoFeatureConfig> {
             BlockPos pos = new BlockPos((x << 4) + 9, 0, (z << 4) + 9);
 
             Biome b = biomes.getBiome(pos);
-            return Vaults.validBiomes.contains(b)
-                && Meson.isModuleEnabled("strange:vaults")
-                && Math.abs(pos.getX()) > MIN_DISTANCE
+            return Math.abs(pos.getX()) > MIN_DISTANCE
                 && Math.abs(pos.getZ()) > MIN_DISTANCE
                 && gen.hasStructure(b, Vaults.structure);
         }

--- a/src/main/java/svenhjol/strange/runestones/module/StoneCircles.java
+++ b/src/main/java/svenhjol/strange/runestones/module/StoneCircles.java
@@ -1,5 +1,9 @@
 package svenhjol.strange.runestones.module;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import net.minecraft.item.Items;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -8,7 +12,11 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.feature.NoFeatureConfig;
 import net.minecraft.world.gen.feature.structure.Structure;
-import net.minecraft.world.storage.loot.*;
+import net.minecraft.world.storage.loot.ItemLootEntry;
+import net.minecraft.world.storage.loot.LootEntry;
+import net.minecraft.world.storage.loot.LootParameters;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraft.world.storage.loot.LootTables;
 import net.minecraftforge.event.LootTableLoadEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -23,14 +31,9 @@ import svenhjol.meson.iface.Module;
 import svenhjol.strange.Strange;
 import svenhjol.strange.base.StrangeCategories;
 import svenhjol.strange.base.helper.LocationHelper;
-import svenhjol.strange.base.helper.StructureHelper;
 import svenhjol.strange.base.helper.VersionHelper;
 import svenhjol.strange.runestones.structure.StoneCirclePiece;
 import svenhjol.strange.runestones.structure.StoneCircleStructure;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 @Module(mod = Strange.MOD_ID, category = StrangeCategories.RUNESTONES, hasSubscriptions = true,
     description = "Stone circles are surface structures of stone pillars with a runestone on top.\n" +
@@ -92,13 +95,21 @@ public class StoneCircles extends MesonModule {
             if (!validBiomes.contains(biome)) validBiomes.add(biome);
         });
 
-        final List<Biome> overworldBiomes = StructureHelper.getOverworldBiomes();
+//        final List<Biome> overworldBiomes = StructureHelper.getOverworldBiomes();
 
         ForgeRegistries.BIOMES.forEach(biome -> {
-            if (!overworldBiomes.contains(biome))
-                return;
+        	// This is commented out so modded biomes gets the structure added as a 
+        	// feature and won't cut off stone circles if those biomes border a valid biome 
+        	// and the stone circle tries to spawn on the border.
+//            if (!overworldBiomes.contains(biome))
+//                return;
 
-            VersionHelper.addStructureToBiome(structure, biome);
+            //Structure can finish generating in any biome so it doesn't get cut off.
+            VersionHelper.addStructureToBiomeFeature(structure, biome);
+            
+            //Only these biomes can start the structure generation.
+            if(validBiomes.contains(biome) && Meson.isModuleEnabled("strange:stone_circles"))
+                VersionHelper.addStructureToBiomeStructure(structure, biome);
         });
     }
 

--- a/src/main/java/svenhjol/strange/runestones/structure/StoneCircleStructure.java
+++ b/src/main/java/svenhjol/strange/runestones/structure/StoneCircleStructure.java
@@ -1,5 +1,8 @@
 package svenhjol.strange.runestones.structure;
 
+import java.util.Objects;
+import java.util.Random;
+
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.MutableBoundingBox;
@@ -11,13 +14,9 @@ import net.minecraft.world.gen.feature.structure.ScatteredStructure;
 import net.minecraft.world.gen.feature.structure.Structure;
 import net.minecraft.world.gen.feature.structure.StructureStart;
 import net.minecraft.world.gen.feature.template.TemplateManager;
-import svenhjol.meson.Meson;
 import svenhjol.strange.Strange;
 import svenhjol.strange.runestones.module.Runestones;
 import svenhjol.strange.runestones.module.StoneCircles;
-
-import java.util.Objects;
-import java.util.Random;
 
 public class StoneCircleStructure extends ScatteredStructure<NoFeatureConfig> {
     public static final int SEED_MODIFIER = 1684681;
@@ -56,9 +55,7 @@ public class StoneCircleStructure extends ScatteredStructure<NoFeatureConfig> {
             BlockPos pos = new BlockPos((x << 4) + 9, 0, (z << 4) + 9);
             Biome b = biomes.getBiome(pos);
 
-            return StoneCircles.validBiomes.contains(b)
-                && Meson.isModuleEnabled("strange:stone_circles")
-                && !Runestones.allDests.isEmpty()
+            return !Runestones.allDests.isEmpty()
                 && gen.hasStructure(b, StoneCircles.structure)
                 && Math.abs(pos.getX()) > MIN_DISTANCE
                 && Math.abs(pos.getZ()) > MIN_DISTANCE;


### PR DESCRIPTION
Structures now are added to biomes they can spawn in and will not get cut off when on edge of a valid biome going into an invalid biome.

The changes is basically removing the validBiome checks from the structure's hasStartAt() method and instead, do the valid biome checks when doing biome.addStructure() so only the valid biomes will attempt generation of the structures. To do this, I split addStructureToBiome() into two methods which are addStructureToBiomeFeature() and addStructureToBiomeStructure() as the two needs to be called at different times.

This should make the structure be more mod friendly and prevent the /locate command hanging forever when in other mod's dimension that attempted to import the structures. 

Fixes: https://github.com/svenhjol/Strange/issues/22

You can make any changes you see fit. Hope this helps!